### PR TITLE
Read APP FW directly from Flash

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -155,7 +155,9 @@ bootutil_img_hash(struct boot_loader_state *state,
     /* No chunk loading, storage is mapped to address space and can
      * be directly given to hashing function.
      */
-    bootutil_sha_update(&sha_ctx, (void *)flash_area_get_off(fap), size);
+#define TL_FLASH_BASE_ADDR 0x20000000
+
+    bootutil_sha_update(&sha_ctx, (void *)(TL_FLASH_BASE_ADDR + flash_area_get_off(fap)), size);
 #else /* MCUBOOT_HASH_STORAGE_DIRECTLY */
 #ifdef MCUBOOT_RAM_LOAD
     bootutil_sha_update(&sha_ctx,

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -155,9 +155,7 @@ bootutil_img_hash(struct boot_loader_state *state,
     /* No chunk loading, storage is mapped to address space and can
      * be directly given to hashing function.
      */
-#define TL_FLASH_BASE_ADDR 0x20000000
-
-    bootutil_sha_update(&sha_ctx, (void *)(TL_FLASH_BASE_ADDR + flash_area_get_off(fap)), size);
+    bootutil_sha_update(&sha_ctx, (void *)(CONFIG_FLASH_BASE_ADDRESS + flash_area_get_off(fap)), size);
 #else /* MCUBOOT_HASH_STORAGE_DIRECTLY */
 #ifdef MCUBOOT_RAM_LOAD
     bootutil_sha_update(&sha_ctx,


### PR DESCRIPTION
- enable CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE to read APP FW directly
- add Telink Flash base address to avoid read wrong address

todo: refine the address usage, Key-pair format and crypto modes